### PR TITLE
refactor: 선박 스케줄을 여러개 조회 시 랜덤 이미지 url 반환 값 추가

### DIFF
--- a/src/main/java/com/example/linkcargo/domain/image/ImageRepository.java
+++ b/src/main/java/com/example/linkcargo/domain/image/ImageRepository.java
@@ -1,9 +1,13 @@
 package com.example.linkcargo.domain.image;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ImageRepository extends JpaRepository<Image, Long> {
-
+    @Query("SELECT i.url FROM Image i WHERE i.name LIKE %:keyword%")
+    List<String> findUrlsByNameContaining(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/example/linkcargo/domain/image/ImageService.java
+++ b/src/main/java/com/example/linkcargo/domain/image/ImageService.java
@@ -42,4 +42,24 @@ public class ImageService {
 
         return savedImages;
     }
+
+
+    public List<String> selectRandomImages(String keyword, int count) {
+        List<String> allUrls = imageRepository.findUrlsByNameContaining(keyword);
+
+        List<String> result = new ArrayList<>(count);
+        String lastUsedUrl = null;
+
+        for (int i = 0; i < count; i++) {
+            String selectedUrl;
+            do {
+                selectedUrl = allUrls.get((int) (Math.random() * allUrls.size()));
+            } while (selectedUrl.equals(lastUsedUrl));
+
+            result.add(selectedUrl);
+            lastUsedUrl = selectedUrl;
+        }
+
+        return result;
+    }
 }

--- a/src/main/java/com/example/linkcargo/domain/schedule/ScheduleService.java
+++ b/src/main/java/com/example/linkcargo/domain/schedule/ScheduleService.java
@@ -1,5 +1,6 @@
 package com.example.linkcargo.domain.schedule;
 
+import com.example.linkcargo.domain.image.ImageService;
 import com.example.linkcargo.domain.port.Port;
 import com.example.linkcargo.domain.port.PortRepository;
 import com.example.linkcargo.domain.schedule.dto.request.ScheduleCreateUpdateRequest;
@@ -8,6 +9,7 @@ import com.example.linkcargo.domain.schedule.dto.response.ScheduleListResponse;
 import com.example.linkcargo.global.response.code.resultCode.ErrorStatus;
 import com.example.linkcargo.global.response.exception.handler.PortHandler;
 import com.example.linkcargo.global.response.exception.handler.ScheduleHandler;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -27,6 +29,7 @@ public class ScheduleService {
 
     private final ScheduleRepository scheduleRepository;
     private final PortRepository portRepository;
+    private final ImageService imageService;
 
     @Transactional
     public Long createSchedule(ScheduleCreateUpdateRequest request) {
@@ -58,12 +61,13 @@ public class ScheduleService {
 
     public ScheduleInfoResponse findSchedule(Long scheduleId) {
         Schedule schedule = scheduleRepository.findById(scheduleId).orElseThrow(() -> new ScheduleHandler(ErrorStatus.SCHEDULE_NOT_FOUND));
-        return ScheduleInfoResponse.fromEntity(schedule);
+        return ScheduleInfoResponse.fromEntity(schedule,"");
     }
 
     public ScheduleListResponse findSchedules(int page, int size) {
         Page<Schedule> schedulePage = scheduleRepository.findAll(PageRequest.of(page,size));
-        return ScheduleListResponse.fromEntity(schedulePage);
+        List<String> imageUrls = imageService.selectRandomImages("vessel",schedulePage.getSize());
+        return ScheduleListResponse.fromEntity(schedulePage,imageUrls);
     }
 
     @Transactional
@@ -107,8 +111,9 @@ public class ScheduleService {
     public ScheduleListResponse searchSchedules(int page, int size) {
         LocalDateTime now = LocalDateTime.now();
         Pageable pageable = PageRequest.of(page, size, Sort.by("ETD").ascending());
-
         Page<Schedule> schedulesPage = scheduleRepository.findByETDAfter(now, pageable);
-        return ScheduleListResponse.fromEntity(schedulesPage);
+        List<String> imageUrls = imageService.selectRandomImages("vessel",schedulesPage.getSize());
+
+        return ScheduleListResponse.fromEntity(schedulesPage, imageUrls);
     }
 }

--- a/src/main/java/com/example/linkcargo/domain/schedule/dto/response/ScheduleInfoResponse.java
+++ b/src/main/java/com/example/linkcargo/domain/schedule/dto/response/ScheduleInfoResponse.java
@@ -9,6 +9,7 @@ public record ScheduleInfoResponse(
         Long id,
         Long exportPortId,
         Long importPortId,
+        String imageUrl,
         String carrier,
         String vessel,
         LocalDateTime ETD,
@@ -20,11 +21,12 @@ public record ScheduleInfoResponse(
         LocalDateTime created_at,
         LocalDateTime updated_at
 ) {
-    public static ScheduleInfoResponse fromEntity(Schedule schedule) {
+    public static ScheduleInfoResponse fromEntity(Schedule schedule, String imageUrl) {
         return new ScheduleInfoResponse(
                 schedule.getId(),
                 schedule.getExportPort().getId(),
                 schedule.getImportPort().getId(),
+                imageUrl,
                 schedule.getCarrier(),
                 schedule.getVessel(),
                 schedule.getETD(),

--- a/src/main/java/com/example/linkcargo/domain/schedule/dto/response/ScheduleListResponse.java
+++ b/src/main/java/com/example/linkcargo/domain/schedule/dto/response/ScheduleListResponse.java
@@ -1,6 +1,8 @@
 package com.example.linkcargo.domain.schedule.dto.response;
 
 import com.example.linkcargo.domain.schedule.Schedule;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.Builder;
 import org.springframework.data.domain.Page;
 
@@ -13,10 +15,14 @@ public record ScheduleListResponse(
         int totalPages,
         long totalElements
 ) {
-    public static ScheduleListResponse fromEntity(Page<Schedule> schedulePage) {
-        List<ScheduleInfoResponse> scheduleResponses = schedulePage.getContent().stream()
-                .map(ScheduleInfoResponse::fromEntity)
-                .toList();
+    public static ScheduleListResponse fromEntity(Page<Schedule> schedulePage, List<String> imageUrls) {
+        List<ScheduleInfoResponse> scheduleResponses = IntStream.range(0, schedulePage.getContent().size())
+            .mapToObj(i -> {
+                Schedule schedule = schedulePage.getContent().get(i);
+                String imageUrl = imageUrls.get(i % imageUrls.size());
+                return ScheduleInfoResponse.fromEntity(schedule, imageUrl);
+            })
+            .collect(Collectors.toList());
 
         return ScheduleListResponse.builder()
                 .schedules(scheduleResponses)


### PR DESCRIPTION
## 📌 이슈

- Resolves #31 

## 🙋🏻‍♂️ 어떤 PR인가요?

- [x] 선박 스케줄 여러 개 조회 시 response값에 랜덤한 이미지의 url을 추가

## ✅ Check List

- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
- [x] 적절한 라벨 설정
- [x] PR에 해당되는 Issue를 연결 완료
