### PR TITLE
refactor: 선박 스케줄 검색 API 파라미터 수정

### DIFF
--- a/src/main/java/com/example/linkcargo/domain/schedule/ScheduleController.java
+++ b/src/main/java/com/example/linkcargo/domain/schedule/ScheduleController.java
@@ -97,17 +97,19 @@ public class ScheduleController {
         return ApiResponse.onSuccess(SuccessStatus._OK);
     }
 
-    @Operation(summary = "선박 스케줄 검색", description = "ETD 기준으로 필터링 및 정렬된 선박 스케줄을 검색합니다.")
+    @Operation(summary = "선박 스케줄 검색", description = "수출항, 수입항 번호가 일치하면서, ETD 기준으로 필터링 및 정렬된 선박 스케줄을 검색합니다.")
     @GetMapping("/search")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
     })
     public ApiResponse<ScheduleListResponse> searchSchedules(
             @AuthenticationPrincipal CustomUserDetail userDetail,
+            @Parameter(description = "수출항 ID") @RequestParam Long exportPortId,
+            @Parameter(description = "수입항 ID") @RequestParam Long importPortId,
             @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "10") int size
     ) {
-        ScheduleListResponse schedules = scheduleService.searchSchedules(page, size);
+        ScheduleListResponse schedules = scheduleService.searchSchedules(exportPortId, importPortId, page, size);
         return ApiResponse.onSuccess(schedules);
     }
 

--- a/src/main/java/com/example/linkcargo/domain/schedule/ScheduleRepository.java
+++ b/src/main/java/com/example/linkcargo/domain/schedule/ScheduleRepository.java
@@ -8,6 +8,6 @@ import java.time.LocalDateTime;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     boolean existsByCarrierAndETDAndETAAndTransportType(String carrier, LocalDateTime etd, LocalDateTime eta, TransportType transportType);
-    Page<Schedule> findByETDAfter(LocalDateTime ETD, Pageable pageable);
+    Page<Schedule> findByExportPortIdAndImportPortIdAndETDAfter(Long exportPortId, Long importPortId, LocalDateTime etd, Pageable pageable);
 
 }

--- a/src/main/java/com/example/linkcargo/domain/schedule/ScheduleService.java
+++ b/src/main/java/com/example/linkcargo/domain/schedule/ScheduleService.java
@@ -108,10 +108,10 @@ public class ScheduleService {
         }
     }
 
-    public ScheduleListResponse searchSchedules(int page, int size) {
+    public ScheduleListResponse searchSchedules(Long exportPortId, Long importPortId, int page, int size) {
         LocalDateTime now = LocalDateTime.now();
         Pageable pageable = PageRequest.of(page, size, Sort.by("ETD").ascending());
-        Page<Schedule> schedulesPage = scheduleRepository.findByETDAfter(now, pageable);
+        Page<Schedule> schedulesPage = scheduleRepository.findByExportPortIdAndImportPortIdAndETDAfter(exportPortId, importPortId, now, pageable);
         List<String> imageUrls = imageService.selectRandomImages("vessel",schedulesPage.getSize());
 
         return ScheduleListResponse.fromEntity(schedulesPage, imageUrls);


### PR DESCRIPTION
## 📌 이슈

- Resolves #34 

## 🙋🏻‍♂️ 어떤 PR인가요?

- [x] 선박 스케줄 검색 API에서 수출항, 수입항 ID를 파라미터로 받도록 수정

## ✅ Check List

- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
- [x] 적절한 라벨 설정
- [x] PR에 해당되는 Issue를 연결 완료
