### PR TITLE
리프레시 토큰 유니크, 재발급 시 기존 토큰 삭제 설정

### DIFF
--- a/src/main/java/com/example/linkcargo/domain/token/RefreshToken.java
+++ b/src/main/java/com/example/linkcargo/domain/token/RefreshToken.java
@@ -15,7 +15,7 @@ public class RefreshToken {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    @Column(name = "user_id", nullable = false)
+    @Column(name = "user_id", nullable = false, unique = true)
     private Long userId;
 
     @Column(name = "token", nullable = false)

--- a/src/main/java/com/example/linkcargo/domain/token/RefreshTokenService.java
+++ b/src/main/java/com/example/linkcargo/domain/token/RefreshTokenService.java
@@ -66,7 +66,7 @@ public class RefreshTokenService {
                 tokenResponse.refreshToken());
             // 기존 리프레시 토큰 제거 
             refreshTokenRepository.deleteByUserId(customUserDetail.getId());
-            // 리프레시 토큰 저장
+            // 새 리프레시 토큰 저장
             refreshTokenRepository.save(refreshToken);
             return tokenResponse;
         } catch (AuthenticationException e) {
@@ -103,7 +103,9 @@ public class RefreshTokenService {
 
         String accessToken = jwtProvider.generateAccessToken(userId, email);
         deleteByUserId(userId); // 기존 리프레시 토큰 삭제
+        // 새 리프레시 토큰 생성 및 저장
         String newRefreshToken = jwtProvider.generateRefreshToken(userId, email);
+        refreshTokenRepository.save(new RefreshToken(userId, newRefreshToken));
         return new TokenResponse(accessToken, newRefreshToken);
     }
 

--- a/src/main/java/com/example/linkcargo/domain/token/RefreshTokenService.java
+++ b/src/main/java/com/example/linkcargo/domain/token/RefreshTokenService.java
@@ -64,6 +64,9 @@ public class RefreshTokenService {
             TokenResponse tokenResponse = createTokens(customUserDetail);
             RefreshToken refreshToken = new RefreshToken(customUserDetail.getId(),
                 tokenResponse.refreshToken());
+            // 기존 리프레시 토큰 제거 
+            refreshTokenRepository.deleteByUserId(customUserDetail.getId());
+            // 리프레시 토큰 저장
             refreshTokenRepository.save(refreshToken);
             return tokenResponse;
         } catch (AuthenticationException e) {


### PR DESCRIPTION
## 📌 이슈

- Resolves #79

## 🙋🏻‍♂️ 어떤 PR인가요?

- 리프레시 토큰 유니크, 재발급 시 기존 토큰 삭제 설정

## ✅ Check List

- [ ] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
- [ ] 적절한 라벨 설정
- [ ] PR에 해당되는 Issue를 연결 완료
