### PR TITLE
채팅방 스케줄 정보 업데이트 안되도록 수정

### DIFF
--- a/src/main/java/com/example/linkcargo/domain/chat/ChatService.java
+++ b/src/main/java/com/example/linkcargo/domain/chat/ChatService.java
@@ -44,7 +44,8 @@ public class ChatService {
         // 채팅방이 존재하는 경우
         if (chatRoom.isPresent()) {
             // 해당 채팅방의 스케줄 업데이트(동일할 수도 있고 다른 스케줄일 수도 있음)
-            chatRoom.get().setSchedule(chatRoomIdRequest.schedule());
+            // TODO 나중에 주석 제거해야 함
+//            chatRoom.get().setSchedule(chatRoomIdRequest.schedule());
             return chatRoom.get(); // 채팅방 반환
         }
 


### PR DESCRIPTION
## 📌 이슈

- Resolves #113 

## 🙋🏻‍♂️ 어떤 PR인가요?

-채팅방 스케줄 정보 업데이트 안되도록 수정

## ✅ Check List

- [ ] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
- [ ] 적절한 라벨 설정
- [ ] PR에 해당되는 Issue를 연결 완료
